### PR TITLE
Replace D3.js project card grid with AirTable gallery embed

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -179,6 +179,7 @@
                 </div>
             </div>
             <div class="row" id="projects-container">
+		    <iframe class="airtable-embed" src="https://airtable.com/embed/shrMSWjORtoYTJpHW?backgroundColor=cyan&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
             </div>
             <div class="row">
               <div class='col-lg-12 text-center'>
@@ -260,23 +261,6 @@
     <script type="text/javascript">
     var func = function(window, d3, $) {
       d3.json("./data.json?q=2016", function(data) {
-        d3.select("#projects-container").selectAll(".project-content-container")
-          .data(data)
-          .enter()
-          .append("div")
-            .attr("class", "project-content-container col-lg-4 col-sm-6")
-            .html(function(d) {
-
-              var owner = d.owner_url != "" ? "<a href='" + d.owner_url + "'>" + d.owner + "</a>" : d.owner;
-              var channel_button = d.channel && d.channel != "" ? "<a href='//progco.de/join'\n                data-toggle=\"tooltip\"\n                title=\"" + d.channel + "\"\n                data-placement=\"top\"\n                class='proj-links'><img src='./img/slack.png' height='20' width='20'></a>" : "";
-
-              var project_button = d.project_url && d.project_url != "" ? "\n                <a href='" + d.project_url + "'\n                  data-toggle=\"tooltip\"\n                  title=\"Contribute\"\n                  data-placement=\"top\"\n                  class='proj-links'><i class='fa fa-github fa-fw' aria-hidden='true'></i></a>\n              " : "";
-              var ret = "\n            <div class='project-item'>\n              <div class='project-image' style='background-image: url(" + d.site_image + ")'>\n                <div class=''>\n                  \n                  <div class='clearfix'></div>\n                </div>\n              </div>\n              <div class='project-details'>\n                <div>\n                  <span class='owner-image' style='background-image: url(" + d.owner_image + ")'></span>\n                  <h4><a href='" + d.site_url + "'>" + d.name + "</a></h4>\n                  <h5>" + d.description + "</h5>\n                </div>\n                <div class='clearfix'></div>\n                <div class='links-area'>\n                  " + channel_button + "&nbsp;" + project_button + "\n                </div>\n              </div>\n            </div>\n            "
-              ;
-
-              return ret;
-            });
-
         $(function () {
           $('[data-toggle="tooltip"]').tooltip()
         })


### PR DESCRIPTION
Here's what it looks like:

![screenshot from 2018-07-20 17-20-21](https://user-images.githubusercontent.com/228733/43030150-ccb72eae-8c41-11e8-95b0-d0bd26d911bf.png)

And you can edit them on AirTable like a spreadsheet:

![screenshot from 2018-07-20 17-25-14](https://user-images.githubusercontent.com/228733/43030163-e7961bf4-8c41-11e8-8d55-301cd007a4b5.png)


