### PR TITLE
Add Every Public Meeting to featured projects

### DIFF
--- a/web/data.json
+++ b/web/data.json
@@ -49,4 +49,13 @@
 	"site_image": "https://avatars3.githubusercontent.com/u/26628693",
 	"is_featured": "TRUE",
 	"channel": "#maps-for-change"
+},  {
+	"name": "Every Public Meeting",
+	"owner": "Include People",
+	"description": "Local meetings happen all the time. Find them easily and turn people out with a single text.",
+  "site_url": "https://github.com/includepeople/everypublicmeeting",
+	"project_url": "http://everypublicmeeting.com",
+	"site_image": "https://i.imgur.com/ryvoZEu.png",
+	"is_featured": "TRUE",
+	"channel": "#local-organizing"
 }]


### PR DESCRIPTION
Adding Every Public Meeting to the data.json file for inclusion on the homepage.

![everypublicmeeting](https://user-images.githubusercontent.com/228733/43360267-a7bb1ae4-9267-11e8-9680-2c2ab857f415.png)
