### PR TITLE
Use brand identity colors

### DIFF
--- a/web/css/app.css
+++ b/web/css/app.css
@@ -402,9 +402,9 @@ h6 {
   padding-top: 160px;
   padding-bottom: 0px;
   text-align: center;
-  background-color: #73e9cf; }
+  background-color: #64ffda; }
   .intro-header .btn-lg {
-    background-color: #e21065; }
+    background-color: #ea098c }
 
 .intro-message {
   position: relative;
@@ -555,24 +555,25 @@ h3 a {
 #the-plan {
   padding-top: 80px;
   padding-bottom: 80px;
-  background: #b39cff; }
+  background: #a0f;
+  color: white; }
   #the-plan .img-container {
     height: 110px; }
 
 #projects-area {
-  background: #f2cd76; }
+  background: white; }
 
 #get-started {
-  background: #73e9cf;
+  background: #64ffda;
   padding: 50px 0 80px; }
   #get-started .btn-lg {
     background: #0096fb; }
 
 #media {
-  background: #eeeee0; }
+  background: #white; }
 
 .btn-md.btn-blue {
-  background-color: #0096fb;
+  background-color: #00b0ff;
   color: white !important;
   border-radius: 20px;
   border: none;
@@ -580,7 +581,7 @@ h3 a {
   margin-top: 10px;
   display: inline-block; }
   .btn-md.btn-blue:hover {
-    background-color: #e21065 !important; }
+    background-color: #ea098c !important; }
 
 nav.navbar-default {
   background-color: white; }
@@ -601,7 +602,9 @@ div#projects-area .project-content-container:hover .project-item .project-image 
 div#projects-area .project-content-container .project-item {
   height: 300px;
   border-radius: 4px;
-  margin-bottom: 30px; }
+  margin-bottom: 30px;
+  border: 1px solid #00b0ff;
+  padding: 0 0 0 1px; }
   div#projects-area .project-content-container .project-item h5 {
     margin-top: 10px !important; }
   div#projects-area .project-content-container .project-item .project-image {

--- a/web/css/app.css
+++ b/web/css/app.css
@@ -555,7 +555,7 @@ h3 a {
 #the-plan {
   padding-top: 80px;
   padding-bottom: 80px;
-  background: #a0f;
+  background: #8800cc;
   color: white; }
   #the-plan .img-container {
     height: 110px; }


### PR DESCRIPTION
Changes related to #18:

- Replaces two yellow-ish backgrounds with white.
- Replaces cyan-green, purple, red, and blue colors with official (similar) hex codes
- Restores border around project items for better visibility on new white background

# Before

1 of 4
![screenshot from 2018-07-28 20-29-43](https://user-images.githubusercontent.com/228733/43362666-12f66ab0-92a5-11e8-90ef-d72ae5fd3dc8.png)

2 of 4
![screenshot from 2018-07-28 20-29-55](https://user-images.githubusercontent.com/228733/43362667-16e11670-92a5-11e8-8f99-a49612de85f6.png)

3 of 4
![screenshot from 2018-07-28 20-30-07](https://user-images.githubusercontent.com/228733/43362668-1afb39d4-92a5-11e8-812a-eed35221950a.png)

4 of 4
![screenshot from 2018-07-28 20-30-19](https://user-images.githubusercontent.com/228733/43362669-1db4b47a-92a5-11e8-969f-bc5256df90e6.png)


# After

1 of 4
![screenshot from 2018-07-28 20-24-34](https://user-images.githubusercontent.com/228733/43362656-d77952d6-92a4-11e8-8cb1-c15ab26b55f0.png)

2 of 4
![screenshot from 2018-07-28 20-24-47](https://user-images.githubusercontent.com/228733/43362658-db26cf4e-92a4-11e8-94c8-008425e5955f.png)

3 of 4
![screenshot from 2018-07-28 20-25-05](https://user-images.githubusercontent.com/228733/43362659-dff5386c-92a4-11e8-8df1-45266af3e7b7.png)

4 of 4
![screenshot from 2018-07-28 20-25-18](https://user-images.githubusercontent.com/228733/43362660-e30a3264-92a4-11e8-967e-7069d57918e5.png)
